### PR TITLE
Expose base classes and hide metaclasses

### DIFF
--- a/openff/nagl/features/__init__.py
+++ b/openff/nagl/features/__init__.py
@@ -1,3 +1,8 @@
 """
 Atom and bond features for GNN models
 """
+from ._base import Feature
+
+__all__ = [
+    "Feature",
+]

--- a/openff/nagl/features/atoms.py
+++ b/openff/nagl/features/atoms.py
@@ -19,7 +19,6 @@ if TYPE_CHECKING:
     from openff.toolkit.topology import Molecule as OFFMolecule
 
 __all__ = [
-    "AtomFeatureMeta",
     "AtomFeature",
     "AtomicElement",
     "AtomConnectivity",
@@ -34,11 +33,11 @@ __all__ = [
 ]
 
 
-class AtomFeatureMeta(FeatureMeta):
+class _AtomFeatureMeta(FeatureMeta):
     registry: ClassVar[Dict[str, Type]] = {}
 
 
-class AtomFeature(Feature, metaclass=AtomFeatureMeta):
+class AtomFeature(Feature, metaclass=_AtomFeatureMeta):
     pass
 
 

--- a/openff/nagl/features/bonds.py
+++ b/openff/nagl/features/bonds.py
@@ -10,7 +10,6 @@ from ._base import CategoricalMixin, Feature, FeatureMeta
 from ._utils import one_hot_encode
 
 __all__ = [
-    "BondFeatureMeta",
     "BondFeature",
     "BondIsAromatic",
     "BondIsInRing",
@@ -20,11 +19,11 @@ __all__ = [
 ]
 
 
-class BondFeatureMeta(FeatureMeta):
+class _BondFeatureMeta(FeatureMeta):
     registry: ClassVar[Dict[str, Type]] = {}
 
 
-class BondFeature(Feature, metaclass=BondFeatureMeta):
+class BondFeature(Feature, metaclass=_BondFeatureMeta):
     pass
 
 

--- a/openff/nagl/nn/_containers.py
+++ b/openff/nagl/nn/_containers.py
@@ -6,7 +6,7 @@ import torch
 from openff.nagl.molecule._dgl import DGLMolecule, DGLMoleculeBatch
 
 from openff.nagl.nn.activation import ActivationFunction
-from openff.nagl.nn.gcn._base import GCNStackMeta, BaseConvModule
+from openff.nagl.nn.gcn._base import _GCNStackMeta, BaseConvModule
 from openff.nagl.nn._sequential import SequentialLayers
 from openff.nagl.nn._pooling import PoolingLayer
 from openff.nagl.nn.postprocess import PostprocessLayer
@@ -24,7 +24,7 @@ class ConvolutionModule(torch.nn.Module):
     ):
         super().__init__()
 
-        gcn_cls = GCNStackMeta._get_class(architecture)
+        gcn_cls = _GCNStackMeta._get_class(architecture)
         self.gcn_layers = gcn_cls.with_layers(
             n_input_features=n_input_features,
             hidden_feature_sizes=hidden_feature_sizes,

--- a/openff/nagl/nn/_models.py
+++ b/openff/nagl/nn/_models.py
@@ -145,7 +145,7 @@ class GNNModel(BaseGNNModel):
         This can be given either as a class,
         e.g. :class:`~openff.nagl.nn.activation.ActivationFunction.ReLU`,
         or as a string, e.g. ``"ReLU"``.
-    postprocess_layer: Union[str, PostprocessLayerMeta]
+    postprocess_layer: Union[str, PostprocessLayer]
         The postprocess layer to use.
         This can be given either as a class,
         e.g. :class:`~openff.nagl.nn.postprocess.ComputePartialCharges`,

--- a/openff/nagl/nn/_models.py
+++ b/openff/nagl/nn/_models.py
@@ -13,9 +13,9 @@ if TYPE_CHECKING:
     from openff.nagl.features.bonds import BondFeature
     from openff.nagl.molecule._dgl.batch import DGLMoleculeBatch
     from openff.nagl.molecule._dgl.molecule import DGLMolecule
-    from openff.nagl.nn.postprocess import PostprocessLayerMeta
+    from openff.nagl.nn.postprocess import PostprocessLayer
     from openff.nagl.nn.activation import ActivationFunction
-    from openff.nagl.nn.gcn._base import GCNStackMeta
+    from openff.nagl.nn.gcn._base import BaseGCNStack
 
 
 def rmse_loss(pred: torch.Tensor, target: torch.Tensor) -> torch.Tensor:
@@ -122,16 +122,16 @@ class GNNModel(BaseGNNModel):
 
     Parameters
     ----------
-    convolution_architecture: Union[str, GCNStackMeta]
+    convolution_architecture: Union[str, BaseGCNStack]
         The graph convolution architecture.
         This can be given either as a class,
-        e.g. :class:`~openff.nagl.nn.gcn._sage.SAGEConvStack`
+        e.g. :class:`~openff.nagl.nn.gcn.SAGEConvStack`
         or as a string, e.g. ``"SAGEConv"``.
     n_convolution_hidden_features: int
         The number of features in each of the hidden convolutional layers.
     n_convolution_layers: int
-        The number of hidden convolutional layers to generate. These are the 
-        layers in the convolutional module between the input layer and the 
+        The number of hidden convolutional layers to generate. These are the
+        layers in the convolutional module between the input layer and the
         pooling layer.
     n_readout_hidden_features: int
         The number of features in each of the hidden readout layers.
@@ -162,6 +162,7 @@ class GNNModel(BaseGNNModel):
     readout_dropout: float
         The dropout probability to use in the readout layers.
     """
+
     @classmethod
     def from_yaml_file(cls, *paths, **kwargs):
         import yaml
@@ -183,13 +184,13 @@ class GNNModel(BaseGNNModel):
 
     def __init__(
         self,
-        convolution_architecture: Union[str, "GCNStackMeta"],
+        convolution_architecture: Union[str, "BaseGCNStack"],
         n_convolution_hidden_features: int,
         n_convolution_layers: int,
         n_readout_hidden_features: int,
         n_readout_layers: int,
         activation_function: Union[str, "ActivationFunction"],
-        postprocess_layer: Union[str, "PostprocessLayerMeta"],
+        postprocess_layer: Union[str, "PostprocessLayer"],
         readout_name: str,
         learning_rate: float,
         atom_features: Tuple["AtomFeature", ...],
@@ -203,13 +204,13 @@ class GNNModel(BaseGNNModel):
         from openff.nagl.nn.activation import ActivationFunction
         from openff.nagl.nn.gcn import GCNStackMeta
         from openff.nagl.nn._pooling import PoolAtomFeatures
-        from openff.nagl.nn.postprocess import PostprocessLayerMeta
+        from openff.nagl.nn.postprocess import _PostprocessLayerMeta
         from openff.nagl.nn._sequential import SequentialLayers
 
         self.readout_name = readout_name
 
         convolution_architecture = GCNStackMeta._get_class(convolution_architecture)
-        postprocess_layer = PostprocessLayerMeta._get_class(postprocess_layer)
+        postprocess_layer = _PostprocessLayerMeta._get_class(postprocess_layer)
         activation_function = ActivationFunction._get_class(activation_function)
         self.atom_features = self._validate_features(atom_features, AtomFeature)
         self.bond_features = self._validate_features(bond_features, BondFeature)
@@ -260,7 +261,7 @@ class GNNModel(BaseGNNModel):
         as_numpy: bool
             Whether to return the result as a numpy array.
             If ``False``, the result will be a ``torch.Tensor``.
-        
+
         Returns
         -------
         result: torch.Tensor or numpy.ndarray
@@ -348,7 +349,7 @@ class GNNModel(BaseGNNModel):
         >>> model.save("model.pt")
         >>> new_model = GNNModel.load("model.pt")
 
-        Notes   
+        Notes
         -----
         This method is not compatible with normal Pytorch
         models saved with ``torch.save``, as it expects
@@ -370,7 +371,7 @@ class GNNModel(BaseGNNModel):
     def save(self, path: str):
         """
         Save this model to a file.
-        
+
         Parameters
         ----------
         path: str

--- a/openff/nagl/nn/_models.py
+++ b/openff/nagl/nn/_models.py
@@ -202,14 +202,14 @@ class GNNModel(BaseGNNModel):
         from openff.nagl.features.atoms import AtomFeature
         from openff.nagl.features.bonds import BondFeature
         from openff.nagl.nn.activation import ActivationFunction
-        from openff.nagl.nn.gcn import GCNStackMeta
+        from openff.nagl.nn.gcn import _GCNStackMeta
         from openff.nagl.nn._pooling import PoolAtomFeatures
         from openff.nagl.nn.postprocess import _PostprocessLayerMeta
         from openff.nagl.nn._sequential import SequentialLayers
 
         self.readout_name = readout_name
 
-        convolution_architecture = GCNStackMeta._get_class(convolution_architecture)
+        convolution_architecture = _GCNStackMeta._get_class(convolution_architecture)
         postprocess_layer = _PostprocessLayerMeta._get_class(postprocess_layer)
         activation_function = ActivationFunction._get_class(activation_function)
         self.atom_features = self._validate_features(atom_features, AtomFeature)

--- a/openff/nagl/nn/gcn/__init__.py
+++ b/openff/nagl/nn/gcn/__init__.py
@@ -1,10 +1,10 @@
 "Architectures for convolutional layers"
 
-from ._base import GCNStackMeta
+from ._base import BaseGCNStack
 from ._sage import SAGEConvStack
 from ._gin import GINConvStack
 
 
-__all__ = ["GCNStackMeta", "SAGEConvStack", "GINConvStack"]
+__all__ = ["BaseGCNStack", "SAGEConvStack", "GINConvStack"]
 
 # TODO: eventually migrate out DGL?

--- a/openff/nagl/nn/gcn/__init__.py
+++ b/openff/nagl/nn/gcn/__init__.py
@@ -1,6 +1,6 @@
 "Architectures for convolutional layers"
 
-from ._base import BaseGCNStack
+from ._base import BaseGCNStack, _GCNStackMeta
 from ._sage import SAGEConvStack
 from ._gin import GINConvStack
 

--- a/openff/nagl/nn/gcn/_base.py
+++ b/openff/nagl/nn/gcn/_base.py
@@ -43,7 +43,7 @@ class BaseConvModule(torch.nn.Module):
     pass
 
 
-class GCNStackMeta(abc.ABCMeta, create_registry_metaclass("name")):
+class _GCNStackMeta(abc.ABCMeta, create_registry_metaclass("name")):
     pass
 
 
@@ -52,7 +52,7 @@ class BaseGCNStack(
     Generic[GCNLayerType],
     ContainsLayersMixin,
     abc.ABC,
-    metaclass=GCNStackMeta,
+    metaclass=_GCNStackMeta,
 ):
     """A wrapper around a stack of GCN graph convolutional layers.
 

--- a/openff/nagl/nn/postprocess.py
+++ b/openff/nagl/nn/postprocess.py
@@ -10,10 +10,8 @@ import torch
 from openff.nagl._base.metaregistry import create_registry_metaclass
 from openff.nagl.molecule._dgl import DGLMolecule, DGLMoleculeBatch
 
-__all__ = ["PostprocessLayerMeta", "PostprocessLayer", "ComputePartialCharges"]
 
-
-class PostprocessLayerMeta(abc.ABCMeta, create_registry_metaclass()):
+class _PostprocessLayerMeta(abc.ABCMeta, create_registry_metaclass()):
     registry: ClassVar[Dict[str, Type]] = {}
 
     def __init__(cls, name, bases, namespace, **kwargs):
@@ -36,7 +34,7 @@ class PostprocessLayerMeta(abc.ABCMeta, create_registry_metaclass()):
     #         )
 
 
-class PostprocessLayer(torch.nn.Module, abc.ABC, metaclass=PostprocessLayerMeta):
+class PostprocessLayer(torch.nn.Module, abc.ABC, metaclass=_PostprocessLayerMeta):
     """A layer to apply to the final readout of a neural network."""
 
     name: ClassVar[str] = ""


### PR DESCRIPTION
This is a bit of a drive-by but I figured it was easier to write this PR than explain it in an issue :/

Previously the abstract base classes for post-processing layers and GCN stacks were private. I realised this when I started to write up some hints on how to write your own and found that the base classes weren't documented. The registry metaclasses, however, are public and documented. I think this could lead to some major confusion, as the actual functionality you need to implement isn't in the metaclass, its in the base class. I think the metaclasses are really implementation details for the string encoding stuff, and they're the metaclasses of the base classes so inheritors shouldn't need to use them explicitly anyway.

So I've...

Changes made in this Pull Request:
<!-- Summarise changes made with dot points below -->
 - Made `AtomFeatureMeta`, `BondFeatureMeta`, `PostprocessLayerMeta` and `GCNStackMeta` private by prepending them with underscores and removing them from `__all__` as appropriate
 - Made `BaseGCNStack` public by adding it to the `gcn` module re-exports
 - Made `Feature` public by adding it to the `feature` module re-exports
 - Updated the `GNNModel` docstring to use the base classes instead of the metaclasses.

I think this was just an oversight but if it's intended then no worries!

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
