### PR TITLE
Document creation of custom features

### DIFF
--- a/docs/designing.md
+++ b/docs/designing.md
@@ -83,10 +83,12 @@ Here we'll go through each option, what it means, and where to find the availabl
 (model_features)=
 ## `atom_features` and `bond_features`
 
-These arguments specify the featurization scheme for the model (see [](featurization_theory). `atom_features` takes a tuple of features from the [`openff.nagl.features.atoms`] module, and `bond_features` a tuple of features from the [`openff.nagl.features.bonds`] module. Each feature is a class that must be instantiated, possibly with some arguments.
+These arguments specify the featurization scheme for the model (see [](featurization_theory)). `atom_features` takes a tuple of features from the [`openff.nagl.features.atoms`] module, and `bond_features` a tuple of features from the [`openff.nagl.features.bonds`] module. Each feature is a class that must be instantiated, possibly with some arguments. Custom features may be implemented by subclassing [`AtomFeature`] or [`BondFeature`]; both share the interface of their base class [`Feature`].
 
 [`openff.nagl.features.atoms`]: openff.nagl.features.atoms
 [`openff.nagl.features.bonds`]: openff.nagl.features.bonds
+[`AtomFeature`]: openff.nagl.features.atoms.AtomFeature
+[`BondFeature`]: openff.nagl.features.bonds.BondFeature
 [`Feature`]: openff.nagl.features.Feature
 
 ## `convolution_architecture`

--- a/openff/nagl/features/_base.py
+++ b/openff/nagl/features/_base.py
@@ -42,7 +42,24 @@ class FeatureMeta(ModelMetaclass, create_registry_metaclass("feature_name")):
 
 
 class Feature(ImmutableModel, abc.ABC):
+    """
+    Abstract base class for atom and bond features.
+
+    Features with length one can simply inherit :py:class:`AtomFeature
+    <openff.nagl.features.atoms.AtomFeature>` or
+    :py:class:`BondFeature <openff.nagl.features.bonds.BondFeature>`,
+    implement :py:class:`_encode <encode>`, and define
+    :py:attr:`feature_name`. Complex features should additionally define the
+    :py:attr:`_feature_length` class attribute and set it to the length of the
+    feature.
+
+    See Also
+    ========
+    openff.nagl.features.atoms.AtomFeature, openff.nagl.features.bonds.BondFeature
+    """
+
     feature_name: ClassVar[Optional[str]] = ""
+    """Define a name for the feature"""
     _feature_length: ClassVar[int] = 1
 
     def __init__(self, *args, **kwargs):
@@ -63,6 +80,11 @@ class Feature(ImmutableModel, abc.ABC):
     def encode(self, molecule: "OFFMolecule") -> "torch.Tensor":
         """
         Encode the molecule feature into a tensor.
+
+        The output of this method must have shape :py:attr:`tensor_shape`.
+        Subclasses may instead implement a ``_encode`` method with the same
+        signature as this one. The default implementation of this method
+        will call that one and guarantee an appropriate shape.
         """
         return self._encode(molecule).reshape(self.tensor_shape)
 

--- a/openff/nagl/features/atoms.py
+++ b/openff/nagl/features/atoms.py
@@ -53,13 +53,20 @@ __all__ = [
     # "AtomMorganFingerprint"
 ]
 
+
 class _AtomFeatureMeta(FeatureMeta):
     """Metaclass for registering atom features for string lookup."""
+
     registry: ClassVar[Dict[str, Type]] = {}
 
 
 class AtomFeature(Feature, metaclass=_AtomFeatureMeta):
-    """Abstract base class for features of atoms."""
+    """Abstract base class for features of atoms.
+
+    See :py:class:`Feature<openff.nagl.features.Feature>` for details on how to
+    implement your own atom features.
+    """
+
     pass
 
 

--- a/openff/nagl/features/bonds.py
+++ b/openff/nagl/features/bonds.py
@@ -39,11 +39,17 @@ __all__ = [
 
 class _BondFeatureMeta(FeatureMeta):
     """Metaclass for registering bond features for string lookup."""
+
     registry: ClassVar[Dict[str, Type]] = {}
 
 
 class BondFeature(Feature, metaclass=_BondFeatureMeta):
-    """Abstract base class for features of bonds."""
+    """Abstract base class for features of bonds.
+
+    See :py:class:`Feature<openff.nagl.features.Feature>` for details on how to
+    implement your own bond features.
+    """
+
     pass
 
 


### PR DESCRIPTION
This just adds some docstrings detailing how to implement features and refers people to them in the appropriate part of the books docs.

Since we don't implement private objects, some of the documentation of `Feature` is a bit awkward. I think it works, but might be worth thinking about whether we want to keep user-facing private abstract methods.

Changes made in this Pull Request:
<!-- Summarise changes made with dot points below -->
 - Docstrings for `Feature` and its public methods/attributes
 - `BondFeature` and `AtomFeature` refer the reader to `Feature`
 - `designing.md` also refers reader to `Feature`


PR Checklist
------------
 - [x] Docs?
