### PR TITLE
Switch to base toolkit package

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -15,7 +15,7 @@ dependencies:
   - tqdm
 
   # chemistry
-  - openff-toolkit ==0.11.1
+  - openff-toolkit-base ==0.11.1
   - openff-units
   - pydantic
   - rdkit


### PR DESCRIPTION
<!-- Does this PR fix an issue or relate to an existing discussion? Please link it below after "Fixes #" -->

I'm not necessarily sure this should be merged; the objective here is to see what happens in tests if NAGL is provided `openff-toolkit-base` and if anything is missing and needs to be packaged.

Changes made in this Pull Request:
<!-- Summarise changes made with dot points below -->
 - Switch to using `openff-toolkit-base`

PR Checklist
------------
 - [x] Switch to using `openff-toolkit-base`
 - [ ] Add back any dependencies not brought in by `openff-toolkit-base`
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
