### PR TITLE
Prepare notebooks for central examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The rules for this file:
 ### Authors
 <!-- GitHub usernames of contributors to this release -->
 - @lilyminium
+- @yoshanuikabundi
 
 ### Reviewers
 - 
@@ -34,6 +35,7 @@ The rules for this file:
 ### Changed
 <!-- Changes in existing functionality -->
 - Migrate away from pkg_resources to importlib_resources (PR #35)
+- Update examples for central examples page (PR #40)
 
 ## v0.2.1
 

--- a/examples/prepare-dataset/prepare-dataset.ipynb
+++ b/examples/prepare-dataset/prepare-dataset.ipynb
@@ -2,25 +2,19 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "39925afd-2d45-4e2d-b36d-269df8f6c7f0",
+   "metadata": {},
+   "source": [
+    "# Prepare a NAGL dataset for training"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "ab93793c",
    "metadata": {
     "tags": []
    },
    "source": [
-    "# Prepare a dataset for training\n",
-    "\n",
-    "<br />\n",
-    "<details style=\"border: 1px solid #cfcfcf; border-radius: 2px; background: #f7f7f7;padding:2px;\">\n",
-    "<summary><small>▼ Dependency installation instructions</small></summary>\n",
-    "Install example dependencies into a new Conda environment using the provided environment.yaml:\n",
-    "\n",
-    "```shell\n",
-    "mamba env create --file ../../devtools/conda-envs/examples_env.yaml --name openff-nagl-examples\n",
-    "mamba activate openff-nagl-examples\n",
-    "jupyter notebook prepare-dataset.ipynb\n",
-    "```\n",
-    "</details>\n",
-    "\n",
     "Training a GCN requires a collection of examples that the GCN should reproduce and interpolate between. This notebook describes how to prepare such a dataset for predicting partial charges."
    ]
   },
@@ -214,7 +208,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/examples/train-gnn-notebook/train-gnn-notebook.ipynb
+++ b/examples/train-gnn-notebook/train-gnn-notebook.ipynb
@@ -2,26 +2,19 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "480cf57f-a1ec-4c18-84a6-40af4268511e",
+   "metadata": {},
+   "source": [
+    "# Training a Graph Neural Network with NAGL"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "70ed15cf",
    "metadata": {
     "tags": []
    },
    "source": [
-    "# Training a Graph Neural Network with NAGL\n",
-    "\n",
-    "<br />\n",
-    "<details style=\"border: 1px solid #cfcfcf; border-radius: 2px; background: #f7f7f7;padding:2px;\">\n",
-    "<summary><small>Dependency installation instructions</small></summary>\n",
-    "Install example dependencies into a new Conda environment using the provided environment.yaml:\n",
-    "\n",
-    "```shell\n",
-    "mamba env create --file ../../devtools/conda-envs/examples_env.yaml --name openff-nagl-examples\n",
-    "mamba activate openff-nagl-examples\n",
-    "jupyter notebook train-gnn-notebook.ipynb\n",
-    "```\n",
-    "</details>\n",
-    "\n",
-    "\n",
     "This notebook will go through the process of training a new Graph Neural Network (GNN) on a small dataset of alkanes, and demonstrate inference with the resulting model. On the way, we'll put together a tiny test dataset, and talk a bit about the architecture of the GNN we're training."
    ]
   },
@@ -706,7 +699,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
We're moving towards a central examples page for OpenFF!

- Preview here: https://openff-docs--7.org.readthedocs.build/en/7/examples.html
- Rendered + executed notebook example: https://openff-docs--7.org.readthedocs.build/en/7/examples/openforcefield/openff-nagl/train-gnn-notebook/train-gnn-notebook.html
- Draft PR here: https://github.com/openforcefield/openff-docs/pull/7

This PR just updates the examples to make them work for that purpose. Dependency install instructions are no longer necessary in each notebook because they're being unified in the central examples downloads (see the top of each notebook, though the CSS styling is not final). This should make it easier to both find and consume examples.

Changes to examples are synced when they make their way to conda forge - so users will always have examples that are consistent with the released version. Only the latest version is rendered, but users will be able to find earlier versions through the "View on GitHub" link. Links to run the notebook in Colab or download it with a helpful dependency installation script are also provided.

Changes made in this Pull Request:
<!-- Summarise changes made with dot points below -->
 - Changes titles to make them clear outside the context of NAGL
 - Removes dependency installation instructions, as that is being unified with other examples


PR Checklist
------------
 - [x] CHANGELOG updated?
