### PR TITLE
remove quotes from prefix

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ VCS = git
 style = pep440
 versionfile_source = openff/nagl/_version.py
 versionfile_build = openff/nagl/_version.py
-tag_prefix = 'v'
+tag_prefix = v
 
 [aliases]
 test = pytest


### PR DESCRIPTION
<!-- Does this PR fix an issue or relate to an existing discussion? Please link it below after "Fixes #" -->

Fixes #39 (*I think)

Changes made in this Pull Request:
<!-- Summarise changes made with dot points below -->
 - 
 - 

```
(openff-nagl-test)  ~/pydev/openff-nagl/ [main] python setup.py version
running version
keywords are unexpanded, not using
got version from VCS {'version': '0+untagged.107.g210d8d6', 'full-revisionid': '210d8d60535731e5a02ffa8375ea277dd1e39303', 'dirty': False, 'error': None, 'date': '2023-07-04T15:40:45+1000'}
Version: 0+untagged.107.g210d8d6
 full-revisionid: 210d8d60535731e5a02ffa8375ea277dd1e39303
 dirty: False
 date: 2023-07-04T15:40:45+1000
```
```
(openff-nagl-test)  ~/pydev/openff-nagl/ [fix-versioneer-prefix*] python setup.py version
running version
keywords are unexpanded, not using
got version from VCS {'version': '0.2.2+2.g210d8d6.dirty', 'full-revisionid': '210d8d60535731e5a02ffa8375ea277dd1e39303', 'dirty': True, 'error': None, 'date': '2023-07-04T15:40:45+1000'}
Version: 0.2.2+2.g210d8d6.dirty
 full-revisionid: 210d8d60535731e5a02ffa8375ea277dd1e39303
 dirty: True
```
PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
