### PR TITLE
Install dgl from conda-forge

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -28,7 +28,7 @@ jobs:
         fail-fast: false
         matrix:
           os: [macOS-latest, ubuntu-latest]
-          python-version: ["3.9", "3.10", "3.11"]
+          python-version: ["3.9", "3.10"]
           pydantic-version: ["1", "2"]
           include-rdkit: [true, false]
           include-openeye: [true, false]

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -1,6 +1,5 @@
 name: openff-nagl-test
 channels:
-  - dglteam
   - openeye
   - conda-forge
   - defaults


### PR DESCRIPTION
<!-- Does this PR fix an issue or relate to an existing discussion? Please link it below after "Fixes #" -->

Fixes #

Changes made in this Pull Request:
<!-- Summarise changes made with dot points below -->
 - Now that DGL is on conda-forge, let's install from there.
 - We have to downgrade to supporting a max of 3.10 for this though, since dgl on conda-forge is not yet 3.11 compatible. It's likely coming soon since dgl on dglteam already does support 3.11.


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
