### PR TITLE
Fix bug report template imports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,7 +19,7 @@ about: Create a report to help us improve
 <!-- Show us how to reproduce the failure. If you can, use trajectory files from the test data. Use the code snipped below as a starting point. -->
 
 ``` python
-import openff-nagl
+import openff.nagl
 
 ...
 
@@ -27,7 +27,7 @@ import openff-nagl
 
 ## Current environment ##
 
-- Which version are you using? (run `python -c "import openff-nagl; print(openff-nagl.__version__)"`)
+- Which version are you using? (run `python -c "import openff.nagl; print(openff.nagl.__version__)"`)
 - Which version of Python (`python -V`)?
 - Which operating system?
 - What is the output of `pip list`?


### PR DESCRIPTION
Just a tiny fix, I just saw this on my todo list from the last issue report.

Template imports seem to be using `openff-nagl` instead of `openff.nagl`.

I don't see any point in updating the changelog / authors for such a tiny thing.


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
