### PR TITLE
Remove exclusion of dgl with py3.12, and move python info step

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -42,6 +42,10 @@ jobs:
             # broken OpenMM build for Mac on 3.10
             - os: "macOS-latest"
               python-version: "3.10"
+            # no dgl for 3.12 yet on Mac
+            - include-dgl: true
+              python-version: "3.12"
+              os: "macOS-latest"
             # no openeye for 3.12 yet
             - include-openeye: true
               python-version: "3.12"

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -42,9 +42,6 @@ jobs:
             # broken OpenMM build for Mac on 3.10
             - os: "macOS-latest"
               python-version: "3.10"
-            # no dgl for 3.12 yet
-            - include-dgl: true
-              python-version: "3.12"
             # no openeye for 3.12 yet
             - include-openeye: true
               python-version: "3.12"
@@ -71,12 +68,6 @@ jobs:
       run: |
         python -m pip install . --no-deps
 
-    - name: Python information
-      run: |
-        which python
-        conda info
-        conda list
-
     - uses: ./.github/actions/include-openeye
       if: matrix.include-openeye == true
       with:
@@ -91,6 +82,12 @@ jobs:
     - name: Uninstall RDKit
       if: matrix.include-rdkit == false
       run: conda remove --force rdkit --yes || echo "rdkit not installed"
+
+    - name: Python information
+      run: |
+        which python
+        conda info
+        conda list
 
     - name: Check toolkit installations
       shell: bash -l -c "python -u {0}"


### PR DESCRIPTION
<!-- Does this PR fix an issue or relate to an existing discussion? Please link it below after "Fixes #" -->

DGL just released a Py3.12-compatible version, so updating CI to make use of it.

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
