### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/dev-ci.yaml
+++ b/.github/workflows/dev-ci.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-          os: [macOS-latest, ubuntu-latest]
+          os: [macOS-12, ubuntu-latest]
           python-version: ["3.10", "3.11", "3.12"]
         exclude:
           # mdtraj currently doesn't support MacOS py3.12

--- a/.github/workflows/examples-ci.yaml
+++ b/.github/workflows/examples-ci.yaml
@@ -30,7 +30,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-          os: [macOS-latest, ubuntu-latest]
+          os: [macOS-12, ubuntu-latest]
           python-version: ["3.10", "3.11"]
           pydantic-version: ["2"]
           include-rdkit: [true]

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -45,6 +45,9 @@ jobs:
             # no openeye for 3.12 yet
             - include-openeye: true
               python-version: "3.12"
+            # no builds?
+            - include-dgl: true
+              python-version: "3.12"
 
 
     steps:

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -30,7 +30,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-          os: [macOS-latest, ubuntu-latest]
+          os: [macOS-12, ubuntu-latest]
           python-version: ["3.10", "3.11", "3.12"]
           pydantic-version: ["1", "2"]
           include-rdkit: [false, true]

--- a/devtools/conda-envs/test_env_dgl_true.yaml
+++ b/devtools/conda-envs/test_env_dgl_true.yaml
@@ -27,7 +27,7 @@ dependencies:
   - pyarrow
 
   # gcn
-  - dgl >=1.0
+  - dgl =2.1
   - pytorch >=2.0
   - pytorch-lightning
 


### PR DESCRIPTION
GitHub just upgraded our org to have access to mac M1 runners. This is the new `macos-latest` in CI, and it causes tests to fail for several reasons of varying complexity. In the meantime, we can specifically request the old `macos-12` runners to keep running CI the way it was before. 