### PR TITLE
Remove Python 3.12 exclusions from CI

### DIFF
--- a/.github/workflows/dev-ci.yaml
+++ b/.github/workflows/dev-ci.yaml
@@ -1,4 +1,4 @@
-name: Dev version CI
+name: Upstream nightly version CI
 on:
   schedule:
     # weekly tests, Sundays at midnight
@@ -24,11 +24,6 @@ jobs:
         matrix:
           os: [macOS-12, ubuntu-latest]
           python-version: ["3.10", "3.11", "3.12"]
-          exclude:
-            # mdtraj currently doesn't support MacOS py3.12
-            - os: "macOS-latest"
-              python-version: "3.12"
-
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -39,9 +39,6 @@ jobs:
           exclude:
             - include-rdkit: false
               include-openeye: false
-            # Can't support 3.12 on Mac yet
-            - python-version: "3.12"
-              os: "macOS-latest"
             # no openeye for 3.12 yet
             - include-openeye: true
               python-version: "3.12"


### PR DESCRIPTION
Packages have updated so past incompatible environments are now possible. Also renames nightly CI.


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
