### PR TITLE
Try testing dgl=2.2

### DIFF
--- a/devtools/conda-envs/test_env_dgl_true.yaml
+++ b/devtools/conda-envs/test_env_dgl_true.yaml
@@ -27,7 +27,7 @@ dependencies:
   - pyarrow
 
   # gcn
-  - dgl =2.2
+  - dgl >=1.0,<=2.1
   - pytorch >=2.0
   - pytorch-lightning
 

--- a/devtools/conda-envs/test_env_dgl_true.yaml
+++ b/devtools/conda-envs/test_env_dgl_true.yaml
@@ -27,7 +27,7 @@ dependencies:
   - pyarrow
 
   # gcn
-  - dgl =2.1
+  - dgl =2.2
   - pytorch >=2.0
   - pytorch-lightning
 


### PR DESCRIPTION
This PR tries testing DGL 2.2. Partially so I can update pins in the NAGL feedstock. We already know 2.1 works due to the previous pin, and the nightly version does not because of graphbolt incompatibilities (??)

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
