### PR TITLE
Check lookup tables for values before ChemicalDomains

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,9 @@ The rules for this file:
 ### Changed
 - Removed unused, undocumented code paths, and updated docs (PR #132)
 
+### Fixed
+- Check lookup tables for allowed molecules before ChemicalDomain for forbidden ones (PR #145, Issue #144)
+
 
 ## v0.4.0 -- 2024-07-18
 

--- a/openff/nagl/nn/_models.py
+++ b/openff/nagl/nn/_models.py
@@ -217,6 +217,7 @@ class GNNModel(BaseGNNModel):
         else:
             tensor = torch.empty
         for property_name, value in results[0].items():
+            print(as_numpy, value, value.dtype)
             combined_results[property_name] = tensor(
                 molecule.n_atoms,
                 dtype=value.dtype
@@ -304,6 +305,8 @@ class GNNModel(BaseGNNModel):
         
         computed_value_keys = set(values.keys())
         if computed_value_keys == set(expected_value_keys):
+            if as_numpy:
+                values = {k: v.detach().numpy().flatten() for k, v in values.items()}
             return values
         
         if check_domains:

--- a/openff/nagl/nn/_models.py
+++ b/openff/nagl/nn/_models.py
@@ -278,24 +278,13 @@ class GNNModel(BaseGNNModel):
         -------
         result: Dict[str, torch.Tensor] or Dict[str, numpy.ndarray]
         """
-        if check_domains:
-            is_supported, error = self.chemical_domain.check_molecule(
-                molecule, return_error_message=True
-            )
-            if not is_supported:
-                if error_if_unsupported:
-                    raise ValueError(error)
-                else:
-                    warnings.warn(error)
 
-        try:
-            values = self._compute_properties_dgl(molecule)
-        except (MissingOptionalDependencyError, TypeError):
-            values = self._compute_properties_nagl(molecule)
-        
+        values = {}
+
+        expected_value_keys = list(self.readout_modules.keys())
+
         if check_lookup_table and self.lookup_tables:
-            property_names = list(values)
-            for property_name in property_names:
+            for property_name in expected_value_keys:
                 try:
                     value = self._check_property_lookup_table(
                         molecule=molecule,
@@ -311,6 +300,27 @@ class GNNModel(BaseGNNModel):
                         f"Using lookup table for property {property_name}"
                     )
                     values[property_name] = value
+
+        
+        computed_value_keys = set(values.keys())
+        if computed_value_keys == set(expected_value_keys):
+            return values
+        
+        if check_domains:
+            is_supported, error = self.chemical_domain.check_molecule(
+                molecule, return_error_message=True
+            )
+            if not is_supported:
+                if error_if_unsupported:
+                    raise ValueError(error)
+                else:
+                    warnings.warn(error)
+
+        try:
+            values = self._compute_properties_dgl(molecule)
+        except (MissingOptionalDependencyError, TypeError):
+            values = self._compute_properties_nagl(molecule)
+        
 
         if as_numpy:
             values = {k: v.detach().numpy().flatten() for k, v in values.items()}

--- a/openff/nagl/tests/nn/test_model.py
+++ b/openff/nagl/tests/nn/test_model.py
@@ -429,7 +429,7 @@ class TestGNNModelRC3:
     def test_lookup_table_before_chemical_domain(self, model):
         hcl = Molecule.from_mapped_smiles("[Cl:1][H:2]")
         expected_charges = [-0.1680,  0.1680]
-        charges = model.compute_property(hcl, as_numpy=True, check_lookup_table=True)
+        charges = model.compute_property(hcl, as_numpy=True, check_domains=True)
         assert_allclose(charges, expected_charges, atol=1e-5)
 
     @pytest.mark.xfail(reason="Model does not include 0 bonds as feature")

--- a/openff/nagl/tests/nn/test_model.py
+++ b/openff/nagl/tests/nn/test_model.py
@@ -426,6 +426,12 @@ class TestGNNModelRC3:
 
         assert_allclose(charges, expected_charges, atol=1e-5)
 
+    def test_lookup_table_before_chemical_domain(self, model):
+        hcl = Molecule.from_mapped_smiles("[Cl:1][H:2]")
+        expected_charges = [-0.1680,  0.1680]
+        charges = model.compute_property(hcl, as_numpy=True, check_lookup_table=True)
+        assert_allclose(charges, expected_charges, atol=1e-5)
+
     @pytest.mark.xfail(reason="Model does not include 0 bonds as feature")
     def test_assign_partial_charges_to_ion(self, model):
         mol = Molecule.from_smiles("[Cl-]")


### PR DESCRIPTION
<!-- Does this PR fix an issue or relate to an existing discussion? Please link it below after "Fixes #" -->

Fixes #144 

Changes made in this Pull Request:
<!-- Summarise changes made with dot points below -->
- This PR checks lookup tables first before the ChemicalDomain with excluded SMARTS patterns, allowing molecules such as HCl through.

PR Checklist
------------
 - [x] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
