### PR TITLE
Fix CI warnings

### DIFF
--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -93,7 +93,7 @@ jobs:
 
     - name: Run tests
       run: |
-        python -m pytest -n 4 -v --cov=openff/nagl --cov-config=setup.cfg --cov-append --cov-report=xml --color=yes openff/nagl/
+        python -m pytest -v --cov=openff/nagl --cov-config=setup.cfg --cov-append --cov-report=xml --color=yes openff/nagl/
 
     - name: codecov
       uses: codecov/codecov-action@v4

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -91,6 +91,11 @@ jobs:
         assert str(OPENEYE_AVAILABLE).lower() == '${{ matrix.include-openeye }}'
         assert str(RDKIT_AVAILABLE).lower() == '${{ matrix.include-rdkit }}'
 
+    - name: Check DGL installation
+      if: matrix.include-dgl == true
+      run: |
+        python -c "import dgl"
+
     - name: Run tests
       run: |
         python -m pytest -v --cov=openff/nagl --cov-config=setup.cfg --cov-append --cov-report=xml --color=yes openff/nagl/

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -181,6 +181,7 @@ jobs:
         auto-update-conda: true
         show-channel-urls: true
         channels: conda-forge, defaults
+        channel-priority: true
 
     - name: Build from source
       run: |

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -30,7 +30,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-          os: [macOS-12, ubuntu-latest]
+          os: [macOS-13, macOS-latest, ubuntu-latest]
           python-version: ["3.10", "3.11", "3.12"]
           pydantic-version: ["1", "2"]
           include-rdkit: [false, true]
@@ -39,12 +39,6 @@ jobs:
           exclude:
             - include-rdkit: false
               include-openeye: false
-            # no openeye for 3.12 yet
-            - include-openeye: true
-              python-version: "3.12"
-            # no builds?
-            - include-dgl: true
-              python-version: "3.12"
 
 
     steps:
@@ -182,7 +176,6 @@ jobs:
         python-version: ${{ matrix.python-version }}
         add-pip-as-python-dependency: true
         architecture: x64
-        miniforge-variant: Mambaforge
         use-mamba: true
         auto-update-conda: true
         show-channel-urls: true

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -84,12 +84,6 @@ jobs:
         mkdir -p ~/.dgl
         echo '{"backend": "pytorch"}' > ~/.dgl/config.json
 
-    - name: Python information
-      run: |
-        which python
-        conda info
-        conda list
-
     - name: Check toolkit installations
       shell: bash -l -c "python -u {0}"
       run: |
@@ -186,5 +180,4 @@ jobs:
 
     - name: Check success
       run: |
-        conda activate openff-nagl
         python -c "import openff.nagl ; print(openff.nagl.__version__)"

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -71,11 +71,11 @@ jobs:
       
     - name: Uninstall OpenEye
       if: matrix.include-openeye == false
-      run: conda remove --force openeye-toolkits --yes || echo "openeye not installed"
+      run: micromamba remove --force openeye-toolkits --yes || echo "openeye not installed"
 
     - name: Uninstall RDKit
       if: matrix.include-rdkit == false
-      run: conda remove --force rdkit --yes || echo "rdkit not installed"
+      run: micromamba remove --force rdkit --yes || echo "rdkit not installed"
 
     # See https://github.com/openforcefield/openff-nagl/issues/103
     - name: Rewrite DGL config

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -51,7 +51,7 @@ jobs:
         ulimit -a
 
     - name: Install environment
-      uses: mamba-org/setup-micromamba@v1
+      uses: mamba-org/setup-micromamba@v2
       with:
         environment-file: devtools/conda-envs/test_env_dgl_${{ matrix.include-dgl }}.yaml
         create-args: >-
@@ -171,28 +171,18 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Install conda
-      uses: conda-incubator/setup-miniconda@v3
+      uses: mamba-org/setup-micromamba@v2
       with:
-        python-version: ${{ matrix.python-version }}
-        add-pip-as-python-dependency: true
-        mamba-version: "*"
-        architecture: x64
-        use-mamba: true
-        auto-update-conda: true
-        show-channel-urls: true
-        channels: conda-forge, defaults
-        channel-priority: true
+        environment-name: openff-nagl
+        create-args: >-
+          python=${{ matrix.python-version }}
 
     - name: Build from source
       run: |
-        conda create --name openff-nagl
-        conda activate openff-nagl
-        conda list
-    
-        mamba env update --name openff-nagl --file devtools/conda-envs/docs_env.yaml
+        micromamba env update --name openff-nagl --file devtools/conda-envs/docs_env.yaml
         python --version
         python -m pip install . --no-deps
-        conda list
+        micromamba list
 
     - name: Check success
       run: |

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -175,6 +175,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         add-pip-as-python-dependency: true
+        mamba-version: "*"
         architecture: x64
         use-mamba: true
         auto-update-conda: true

--- a/devtools/conda-envs/test_env_dgl_false.yaml
+++ b/devtools/conda-envs/test_env_dgl_false.yaml
@@ -2,7 +2,6 @@ name: openff-nagl-test
 channels:
   - openeye
   - conda-forge
-  - defaults
 dependencies:
     # Base depends
   - python

--- a/devtools/conda-envs/test_env_dgl_true.yaml
+++ b/devtools/conda-envs/test_env_dgl_true.yaml
@@ -3,7 +3,6 @@ channels:
   - openeye
   - dglteam
   - conda-forge
-  - defaults
 dependencies:
     # Base depends
   - python

--- a/devtools/conda-envs/test_env_dgl_true.yaml
+++ b/devtools/conda-envs/test_env_dgl_true.yaml
@@ -1,7 +1,6 @@
 name: openff-nagl-test
 channels:
   - openeye
-  - dglteam
   - conda-forge
 dependencies:
     # Base depends


### PR DESCRIPTION
Fixes #148 

- CI is getting warnings about using macOS-latest and Mambaforge; this PR upgrades them both. It also removes some Py3.12 exclusions that I think are ready to go now.
- It also switches over to use conda-forge/dgl which is a fully featured install that includes torchdata. Previously that was causing an ImportError on torchdata, which triggered the `pytest.importorskip(dgl)` condition of some tests.


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
