### PR TITLE
Test on MacOS and remove progress bar from example

### DIFF
--- a/.github/workflows/examples-ci.yaml
+++ b/.github/workflows/examples-ci.yaml
@@ -28,65 +28,63 @@ jobs:
     name: Examples CI (${{ matrix.os }}, py-${{ matrix.python-version }}, rdkit=${{ matrix.include-rdkit }}, openeye=${{ matrix.include-openeye }}, dgl=${{ matrix.include-dgl }}), pydantic=${{ matrix.pydantic-version }}
     runs-on: ${{ matrix.os }}
     strategy:
-        fail-fast: false
-        matrix:
-          os: [ubuntu-latest]
-          python-version: ["3.11", "3.12"]
-          pydantic-version: ["2"]
-          include-rdkit: [true]
-          include-openeye: [false]
-          include-dgl: [true]
-
+      fail-fast: false
+      matrix:
+        os: [macOS-12, ubuntu-latest]
+        python-version: ["3.11", "3.12"]
+        pydantic-version: ["2"]
+        include-rdkit: [true]
+        include-openeye: [false]
+        include-dgl: [true]
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Build information
-      run: |
-        uname -a
-        df -h
-        ulimit -a
+      - name: Build information
+        run: |
+          uname -a
+          df -h
+          ulimit -a
 
-    - name: Install environment
-      uses: mamba-org/setup-micromamba@v1
-      with:
-        environment-file: devtools/conda-envs/examples_env.yaml
-        create-args: >-
-          python=${{ matrix.python-version }}
-          pydantic=${{ matrix.pydantic-version }}
+      - name: Install environment
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-file: devtools/conda-envs/examples_env.yaml
+          create-args: >-
+            python=${{ matrix.python-version }}
+            pydantic=${{ matrix.pydantic-version }}
 
-    - name: Install package
-      run: |
-        python -m pip install . --no-deps
+      - name: Install package
+        run: |
+          python -m pip install . --no-deps
 
-    - uses: ./.github/actions/include-openeye
-      if: matrix.include-openeye == true
-      with:
-        openeye-license-text: ${{ secrets.OE_LICENSE }}
-        openeye-license-file: ${{ env.OE_LICENSE }}
+      - uses: ./.github/actions/include-openeye
+        if: matrix.include-openeye == true
+        with:
+          openeye-license-text: ${{ secrets.OE_LICENSE }}
+          openeye-license-file: ${{ env.OE_LICENSE }}
 
-      
-    - name: Uninstall OpenEye
-      if: matrix.include-openeye == false
-      run: conda remove --force openeye-toolkits --yes || echo "openeye not installed"
+      - name: Uninstall OpenEye
+        if: matrix.include-openeye == false
+        run: conda remove --force openeye-toolkits --yes || echo "openeye not installed"
 
-    - name: Uninstall RDKit
-      if: matrix.include-rdkit == false
-      run: conda remove --force rdkit --yes || echo "rdkit not installed"
-    
-    - name: Python information
-      run: |
-        which python
-        conda info
-        conda list
+      - name: Uninstall RDKit
+        if: matrix.include-rdkit == false
+        run: conda remove --force rdkit --yes || echo "rdkit not installed"
 
-    - name: Check toolkit installations
-      shell: bash -l -c "python -u {0}"
-      run: |
-        from openff.toolkit.utils.toolkits import OPENEYE_AVAILABLE, RDKIT_AVAILABLE
-        assert str(OPENEYE_AVAILABLE).lower() == '${{ matrix.include-openeye }}'
-        assert str(RDKIT_AVAILABLE).lower() == '${{ matrix.include-rdkit }}'
+      - name: Python information
+        run: |
+          which python
+          conda info
+          conda list
 
-    - name: Run example notebooks
-      run: |
-        python -m pytest -r fE -v -x --tb=short -nauto --nbval-lax --nbval-cell-timeout=50000 --dist loadscope examples
+      - name: Check toolkit installations
+        shell: bash -l -c "python -u {0}"
+        run: |
+          from openff.toolkit.utils.toolkits import OPENEYE_AVAILABLE, RDKIT_AVAILABLE
+          assert str(OPENEYE_AVAILABLE).lower() == '${{ matrix.include-openeye }}'
+          assert str(RDKIT_AVAILABLE).lower() == '${{ matrix.include-rdkit }}'
+
+      - name: Run example notebooks
+        run: |
+          python -m pytest -r fE -v -x --tb=short -nauto --nbval-lax --dist loadscope examples

--- a/examples/train-gnn-to-electric-field/train-gnn-to-electric-field.ipynb
+++ b/examples/train-gnn-to-electric-field/train-gnn-to-electric-field.ipynb
@@ -551,7 +551,13 @@
   {
    "cell_type": "markdown",
    "id": "79cb1d56-3d70-4307-93f0-0d5956fdb32e",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "source": [
     "### Training the model\n",
     "\n",
@@ -562,7 +568,13 @@
    "cell_type": "code",
    "execution_count": 13,
    "id": "5bfcbce1-8323-4403-a607-89292681375b",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import pytorch_lightning as pl\n",
@@ -573,12 +585,18 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "c8cb0a08-eea6-41e4-9fd6-158204e26e79",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "trainer = pl.Trainer(\n",
     "    max_epochs=100,\n",
-    "    callbacks=[TQDMProgressBar()], # add progress bar\n",
+    "    # callbacks=[TQDMProgressBar()], # add progress bar\n",
     "    accelerator=\"cpu\"\n",
     ")"
    ]
@@ -587,7 +605,13 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f8846142-77f2-4d60-a74e-c3bc3c3ed3ee",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "datamodule = training_model.create_data_module(verbose=False)"
@@ -597,7 +621,13 @@
    "cell_type": "code",
    "execution_count": 14,
    "id": "4e0174d7-a57b-49d9-89a3-5c756adc0d8c",
-   "metadata": {},
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stderr",
@@ -2154,7 +2184,14 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.12.7"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {},
+    "version_major": 2,
+    "version_minor": 0
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
<!-- Does this PR fix an issue or relate to an existing discussion? Please link it below after "Fixes #" -->

Fixes #133 

Changes made in this Pull Request:
<!-- Summarise changes made with dot points below -->
 - Adds MacOS back to examples testing matrix
 - Reduces amount of output sent during fit

The timeout that's being triggered is not the cell timeout (default about 30 minutes), but a hard coded one for the notebook kernel to transmit the cell's output to nbval. My hypothesis is that the fit takes serious time and the progress bar is constantly sending updates to the output, producing more output than can be processed in 5 seconds. Platform differences may reflect that the MacOS runners take more time (and therefore produce more progress bar updates), or something weird to do with how outputs are transmitted.


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
