### PR TITLE
Update/fix docs builds

### DIFF
--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -7,7 +7,7 @@ build:
 
 python:
   install:
-    - method: setuptools
+    - method: pip
       path: .
 
 conda:


### PR DESCRIPTION
<!-- Does this PR fix an issue or relate to an existing discussion? Please link it below after "Fixes #" -->

There was a small cross-interaction between #168 and #172 which didn't show up until they were in the same branch. It seems that `python.install.method: setuptools` internally calls `python seutp.py` but `python.install.method: pip` calls `pip install -e .`.

https://docs.readthedocs.io/en/stable/config-file/v2.html#packages

I tested this with ace4ee9546f939d3839d784a25e6fe4dd29a14a6 in #175 and it works but don't want to just sneak it in to a separate PR. I still intend to merge this without review since it's scoped to already-approved changes.

Changes made in this Pull Request:
<!-- Summarise changes made with dot points below -->
 - Fix RTD config to use `pip install` instead of `python setup.py`


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
