### PR TITLE
Fix aromaticity? perception? changes? in OpenEye 2025.1.1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,15 @@ The rules for this file:
   * accompany each entry with github issue/PR number (Issue #xyz)
 -->
 
+## v0.5.3 -- 2025-08-18
+
+### Fixed
+- Updated openeye_wrapper for behavior changes in reaction 
+  functionality in the 2025.1.1 openeye-toolkits package.
+
+### Authors
+- [@lilyminium]
+
 ## v0.5.2 -- 2025-02-14
 
 ### Fixed

--- a/openff/nagl/toolkits/openeye.py
+++ b/openff/nagl/toolkits/openeye.py
@@ -6,6 +6,7 @@ from typing import Tuple, TYPE_CHECKING, List, Union
 import numpy as np
 
 from openff.units import unit
+from requests import options
 
 from openff.nagl.toolkits._base import NAGLToolkitWrapperBase
 from openff.toolkit.utils.openeye_wrapper import OpenEyeToolkitWrapper
@@ -48,7 +49,10 @@ class NAGLOpenEyeToolkitWrapper(NAGLToolkitWrapperBase, OpenEyeToolkitWrapper):
         for reaction_smarts in normalization_reactions:
             reaction = oechem.OEUniMolecularRxn(reaction_smarts)
             reaction.SetValidateKekule(False)
-            reaction(oemol)
+            options = reaction.GetOptions()
+            # no idea what this does, this is completely undocumented
+            options.SetHydrogenConversions(False)
+            outcome = reaction(oemol)
 
         molecule = self.from_openeye(
             oemol,

--- a/openff/nagl/toolkits/openeye.py
+++ b/openff/nagl/toolkits/openeye.py
@@ -6,7 +6,6 @@ from typing import Tuple, TYPE_CHECKING, List, Union
 import numpy as np
 
 from openff.units import unit
-from requests import options
 
 from openff.nagl.toolkits._base import NAGLToolkitWrapperBase
 from openff.toolkit.utils.openeye_wrapper import OpenEyeToolkitWrapper


### PR DESCRIPTION
<!-- Does this PR fix an issue or relate to an existing discussion? Please link it below after "Fixes #" -->

Fixes #209

Changes made in this Pull Request:
<!-- Summarise changes made with dot points below -->
 - This sets a hitherto nonexistent, and completely undocumented, option to False to recapture earlier OpenEye behaviour
 - I think this is important to include and release so new users do not run into the silent error of perceiving their molecule inputs differently (although: given our resonance enumeration, I should evaluate whether the normalisation actually matters)
 - however, I'm uneasy that I have no idea what I'm doing and just guessed that this new change was what caused the difference in behaviour

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
