### PR TITLE
Do not package test data files by default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,12 @@ maintainers = [
 requires-python = ">=3.10"
 dynamic = ["version"]
 
-[tool.setuptools.packages]
-find = {}
+[tool.setuptools]
+include-package-data = false
+
+[tool.setuptools.packages.find]
+include = ['openff.nagl*']
+exclude = ['openff.nagl.tests.data*']
 
 [project.optional-dependencies]
 test = [


### PR DESCRIPTION
<!-- Does this PR fix an issue or relate to an existing discussion? Please link it below after "Fixes #" -->

Fixes #215

Changes made in this Pull Request:
<!-- Summarise changes made with dot points below -->
 - Do not package `openff/nagl/tests/data/*` by default

---

Focus primarily on the size of the wheels, which I take as a proxy for how large the conda packages will be
```console
$ git checkout upstream/main                                                                                       62fd974
HEAD is now at 62fd974 Bump aws-actions/configure-aws-credentials from 4 to 5 (#213)
$ rm -rf dist/ && python -m build &>/dev/null && ls -lhrS dist                                                     62fd974
total 526184
-rw-r--r--@ 1 mattthompson  staff   117M Sep 17 10:17 openff_nagl-0.0.0.tar.gz
-rw-r--r--@ 1 mattthompson  staff   117M Sep 17 10:17 openff_nagl-0.0.0-py3-none-any.whl
$ git checkout do-not-package-large-test-data                                                                      62fd974
M	docs/CHANGELOG.md
Previous HEAD position was 62fd974 Bump aws-actions/configure-aws-credentials from 4 to 5 (#213)
Switched to branch 'do-not-package-large-test-data'
$ rm -rf dist/ && python -m build &>/dev/null && ls -lhrS dist                              do-not-package-large-test-data
total 263728
-rw-r--r--@ 1 mattthompson  staff   160K Sep 17 10:18 openff_nagl-0.0.0-py3-none-any.whl
-rw-r--r--@ 1 mattthompson  staff   117M Sep 17 10:18 openff_nagl-0.0.0.tar.gz
```

(The repeated one-liner can probably be re-used on other machines.)

---

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [x] CHANGELOG updated?
 - [x] Issue raised/referenced?
