### PR TITLE
Remove macos-13 from CI

### DIFF
--- a/.github/workflows/base-ci.yaml
+++ b/.github/workflows/base-ci.yaml
@@ -30,7 +30,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-          os: [macOS-13, macOS-latest, ubuntu-latest]
+          os: [macOS-latest, ubuntu-latest]
           python-version: ["3.11", "3.12"]
           include-openeye: [false, true]
 

--- a/.github/workflows/base-ci.yaml
+++ b/.github/workflows/base-ci.yaml
@@ -35,7 +35,7 @@ jobs:
           include-openeye: [false, true]
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
 
     - name: Build information
       run: |

--- a/.github/workflows/dev-ci.yaml
+++ b/.github/workflows/dev-ci.yaml
@@ -26,7 +26,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-          os: [macOS-13, macOS-latest, ubuntu-latest]
+          os: [macOS-latest, ubuntu-latest]
           python-version: ["3.11", "3.12"]
 
     steps:

--- a/.github/workflows/dev-ci.yaml
+++ b/.github/workflows/dev-ci.yaml
@@ -30,7 +30,7 @@ jobs:
           python-version: ["3.11", "3.12"]
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
 
     - name: Build information
       run: |

--- a/.github/workflows/examples-ci.yaml
+++ b/.github/workflows/examples-ci.yaml
@@ -39,7 +39,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
 
     - name: Build information
       run: |

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -30,7 +30,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-          os: [macOS-13, macOS-latest, ubuntu-latest]
+          os: [macOS-latest, ubuntu-latest]
           python-version: ["3.11", "3.12"]
           pydantic-version: ["1", "2"]
           include-rdkit: [false, true]

--- a/.github/workflows/gh-ci.yaml
+++ b/.github/workflows/gh-ci.yaml
@@ -42,7 +42,7 @@ jobs:
 
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
 
     - name: Build information
       run: |
@@ -111,7 +111,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
 
     - name: Set up Python
       uses: actions/setup-python@v6
@@ -135,7 +135,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
 
     - name: Set up Python
       uses: actions/setup-python@v6
@@ -166,7 +166,7 @@ jobs:
           python-version: ["3.11", "3.12"]
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
 
     - name: Install conda
       uses: mamba-org/setup-micromamba@v2

--- a/.github/workflows/gpu.yaml
+++ b/.github/workflows/gpu.yaml
@@ -43,7 +43,7 @@ jobs:
     needs:
       - start-aws-runner
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/gpu.yaml
+++ b/.github/workflows/gpu.yaml
@@ -28,7 +28,7 @@ jobs:
           aws-region: us-east-1
       - name: Create cloud runner
         id: aws-start
-        uses: omsf/start-aws-gha-runner@v1.1.0
+        uses: omsf/start-aws-gha-runner@v1.1.1
         with:
           aws_image_id: ami-0d5079d9be06933e5
           aws_instance_type: g4dn.xlarge

--- a/openff/nagl/tests/label/test_labels.py
+++ b/openff/nagl/tests/label/test_labels.py
@@ -103,7 +103,6 @@ class TestLabelCharges:
         columns = ["mapped_smiles", "conformers", "n_conformers", "charges"]
         assert small_dataset.dataset.schema.names == columns
 
-    @pytest.mark.skipif(not OPENEYE_AVAILABLE, reason="AmberTools fails on macOS-13 currently")
     def test_label_alkane_dataset(self):
         # test conformer generation and labelling
         # as in examples


### PR DESCRIPTION
<!-- Does this PR fix an issue or relate to an existing discussion? Please link it below after "Fixes #" -->

Fixes #232 

Changes made in this Pull Request:
<!-- Summarise changes made with dot points below -->
 - Removes macos-13 from the images. I believe this was the last intel mac runner and macOS-latest covers the latest arm architecture, so I don't think it's worth updating this to -14 or -15.


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
