### PR TITLE
Throw fewer warnings

### DIFF
--- a/openff/nagl/label/labels.py
+++ b/openff/nagl/label/labels.py
@@ -159,7 +159,7 @@ class LabelCharges(_BaseLabel):
             for conformer in conformers:
                 mol.assign_partial_charges(
                     charge_method,
-                    use_conformers=None if charge_method is "formal_charge" else [conformer],
+                    use_conformers=None if charge_method == "formal_charge" else [conformer],
                 )
                 charges.append(
                     mol.partial_charges.m_as(unit.elementary_charge)

--- a/openff/nagl/label/labels.py
+++ b/openff/nagl/label/labels.py
@@ -134,7 +134,7 @@ class LabelCharges(_BaseLabel):
     @staticmethod
     def _assign_charges(
         mapped_smiles: str = None,
-        charge_method: ChargeMethodType = "formal_charges",
+        charge_method: ChargeMethodType = "formal_charge",
         conformers: typing.Optional[unit.Quantity] = None,
         use_existing_conformers: bool = False,
     ) -> np.ndarray:

--- a/openff/nagl/label/labels.py
+++ b/openff/nagl/label/labels.py
@@ -159,7 +159,7 @@ class LabelCharges(_BaseLabel):
             for conformer in conformers:
                 mol.assign_partial_charges(
                     charge_method,
-                    use_conformers=[conformer],
+                    use_conformers=None if charge_method is "formal_charge" else [conformer],
                 )
                 charges.append(
                     mol.partial_charges.m_as(unit.elementary_charge)

--- a/openff/nagl/tests/nn/test_model.py
+++ b/openff/nagl/tests/nn/test_model.py
@@ -452,6 +452,10 @@ class TestChargeGNNModelRC3(BaseTestChargeGNNModel):
 
         assert_allclose(charges, expected_charges, atol=1e-5)
 
+
+    @pytest.mark.filterwarnings(
+        "ignore::openff.toolkit.utils.exceptions.MultipleComponentsInMoleculeWarning",
+    )
     @pytest.mark.skipif(not RDKIT_AVAILABLE, reason="requires rdkit")
     @pytest.mark.parametrize(
         "smiles, expected_formal_charges", [
@@ -518,7 +522,11 @@ class TestChargeGNNModelRC4(BaseTestChargeGNNModel):
 
         charges = model.compute_property(mol, as_numpy=True).flatten()
         assert np.isclose(charges[-1], -1.)
-    
+
+
+    @pytest.mark.filterwarnings(
+        "ignore::openff.toolkit.utils.exceptions.MultipleComponentsInMoleculeWarning",
+    )
     def test_assign_partial_charges_to_hcl_salt(self, model):
         mol = Molecule.from_mapped_smiles("[Cl-:1].[H+:2]")
         assert mol.n_atoms == 2

--- a/openff/nagl/tests/utils/test_openff.py
+++ b/openff/nagl/tests/utils/test_openff.py
@@ -389,6 +389,9 @@ def test_molecule_from_dict(openff_methane_uncharged):
     molecule = _molecule_from_dict(graph)
     assert molecule.is_isomorphic_with(openff_methane_uncharged)
 
+@pytest.mark.filterwarnings(
+    "ignore::openff.toolkit.utils.exceptions.MultipleComponentsInMoleculeWarning",
+)
 def test_split_up_molecule():
     # "N.c1ccccc1.C.CCN"
     mapped_smiles = (

--- a/openff/nagl/tests/utils/test_openff.py
+++ b/openff/nagl/tests/utils/test_openff.py
@@ -8,6 +8,7 @@ from openff.nagl.toolkits import NAGLRDKitToolkitWrapper
 from openff.toolkit import RDKitToolkitWrapper
 from openff.toolkit.utils.toolkit_registry import toolkit_registry_manager, ToolkitRegistry
 from openff.toolkit.utils.toolkits import RDKIT_AVAILABLE, OPENEYE_AVAILABLE
+from openff.toolkit.utils.exceptions import MultipleComponentsInMoleculeWarning
 from openff.units import unit
 
 from openff.nagl.toolkits.openff import (
@@ -389,9 +390,6 @@ def test_molecule_from_dict(openff_methane_uncharged):
     molecule = _molecule_from_dict(graph)
     assert molecule.is_isomorphic_with(openff_methane_uncharged)
 
-@pytest.mark.filterwarnings(
-    "ignore::openff.toolkit.utils.exceptions.MultipleComponentsInMoleculeWarning",
-)
 def test_split_up_molecule():
     # "N.c1ccccc1.C.CCN"
     mapped_smiles = (
@@ -400,7 +398,12 @@ def test_split_up_molecule():
         ".[H:25][C:9]([H:26])([H:27])[C:10]([H:28])([H:29])[N:11]([H:30])[H:31]"
         ".[H:12][N:1]([H:13])[H:14]"
     )
-    molecule = Molecule.from_mapped_smiles(mapped_smiles)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            category=MultipleComponentsInMoleculeWarning,
+        )
+        molecule = Molecule.from_mapped_smiles(mapped_smiles)
 
     fragments, indices = split_up_molecule(molecule, return_indices=True)
     assert len(fragments) == 4

--- a/openff/nagl/toolkits/openff.py
+++ b/openff/nagl/toolkits/openff.py
@@ -679,7 +679,9 @@ def smiles_to_inchi_key(smiles: str) -> str:
 
     from openff.toolkit.topology import Molecule
 
-    offmol = Molecule.from_smiles(smiles, allow_undefined_stereo=True)
+    method = "from_mapped_smiles" if ":" in smiles else "from_smiles"
+    offmol = getattr(Molecule, method)(smiles, allow_undefined_stereo=True)
+
     return offmol.to_inchikey(fixed_hydrogens=True)
 
 

--- a/openff/nagl/toolkits/openff.py
+++ b/openff/nagl/toolkits/openff.py
@@ -1,3 +1,4 @@
+import re
 import contextlib
 import copy
 import functools
@@ -679,7 +680,11 @@ def smiles_to_inchi_key(smiles: str) -> str:
 
     from openff.toolkit.topology import Molecule
 
-    method = "from_mapped_smiles" if ":" in smiles else "from_smiles"
+    # Check if the SMILES is mapped by looking for a colon followed by a number,
+    # just looking for colon or brackets alone won't work
+    MAPPED_PATTERN = re.compile(r":\d+")
+
+    method = "from_mapped_smiles" if re.search(MAPPED_PATTERN, smiles) else "from_smiles"
     offmol = getattr(Molecule, method)(smiles, allow_undefined_stereo=True)
 
     return offmol.to_inchikey(fixed_hydrogens=True)


### PR DESCRIPTION
<!-- Does this PR fix an issue or relate to an existing discussion? Please link it below after "Fixes #" -->

I didn't make an issue for this, but it should prevent some warnings from being erroneously directed towards users.

Changes made in this Pull Request:
<!-- Summarise changes made with dot points below -->
 - Filter out warnings in tests when expected
 - ~~Call `Molecule.from_mapped_smiles` when SMILES is mapped, `Molecule.from_smiles` otherwise~~ Do not warn when this happens internally in a narrow code path
- Do not let partial charge method `"formal_charges"` leak in

This eliminates all warnings when I run tests, but I'm not running them with a GPU attached or necessarily checking all optional dependencies.