### PR TITLE
Performance improvements with large molecules

### DIFF
--- a/devtools/conda-envs/base.yaml
+++ b/devtools/conda-envs/base.yaml
@@ -29,3 +29,5 @@ dependencies:
   - pytest-cov
   - pytest-xdist
   - codecov
+
+  - rustworkx

--- a/devtools/conda-envs/docs_env.yaml
+++ b/devtools/conda-envs/docs_env.yaml
@@ -46,3 +46,5 @@ dependencies:
   #  Pip-only installs
   - pip:
     - git+https://github.com/openforcefield/openff-sphinx-theme.git@main
+
+  - rustworkx

--- a/devtools/conda-envs/examples_env.yaml
+++ b/devtools/conda-envs/examples_env.yaml
@@ -48,3 +48,5 @@ dependencies:
 
   # https://github.com/openforcefield/openff-docs/pull/81/files#diff-68677a278ca13dde111a8ae641890bc84d82d1a4e6922d4e498219d5127947c3R29-R30
   - torchdata<=0.10.0
+
+  - rustworkx

--- a/devtools/conda-envs/nightly.yaml
+++ b/devtools/conda-envs/nightly.yaml
@@ -62,4 +62,4 @@ dependencies:
     - git+https://github.com/openforcefield/openff-recharge.git@main
     - git+https://github.com/openforcefield/openff-units.git@main
   
-
+  - rustworkx

--- a/devtools/conda-envs/test_cuda_env.yaml
+++ b/devtools/conda-envs/test_cuda_env.yaml
@@ -44,3 +44,5 @@ dependencies:
   - pytest-cov
   - pytest-xdist
   - codecov
+
+  - rustworkx

--- a/devtools/conda-envs/test_env_dgl_false.yaml
+++ b/devtools/conda-envs/test_env_dgl_false.yaml
@@ -37,3 +37,5 @@ dependencies:
 
   # https://github.com/openforcefield/openff-docs/pull/81/files#diff-68677a278ca13dde111a8ae641890bc84d82d1a4e6922d4e498219d5127947c3R29-R30
   - torchdata<=0.10.0
+
+  - rustworkx

--- a/openff/nagl/toolkits/openff.py
+++ b/openff/nagl/toolkits/openff.py
@@ -752,20 +752,22 @@ def molecule_from_networkx(graph):
     molecule = Molecule()
 
     for _, info in graph.nodes(data=True):
-        molecule.add_atom(
+        molecule._add_atom(
             atomic_number=info["atomic_number"],
             formal_charge=info["formal_charge"],
             is_aromatic=info["is_aromatic"],
             stereochemistry=info.get("stereochemistry", None),
+            invalidate_cache=False,
         )
 
     for u, v, info in graph.edges(data=True):
-        molecule.add_bond(
+        molecule._add_bond(
             u,
             v,
             bond_order=info["bond_order"],
             is_aromatic=info["is_aromatic"],
             stereochemistry=info.get("stereochemistry", None),
+            invalidate_cache=False,
         )
     return molecule
 

--- a/openff/nagl/toolkits/openff.py
+++ b/openff/nagl/toolkits/openff.py
@@ -845,19 +845,21 @@ def _molecule_from_dict(graph: dict[str, dict]) -> "Molecule":
     molecule = Molecule()
     for atom_index in sorted(graph["atoms"]):
         atom = graph["atoms"][atom_index]
-        molecule.add_atom(
+        molecule._add_atom(
             atomic_number=atom["atomic_number"],
             formal_charge=atom["formal_charge"],
             is_aromatic=atom["is_aromatic"],
             stereochemistry=atom.get("stereochemistry", None),
+            invalidate_cache=False,
         )
 
     for (u, v), info in graph["bonds"].items():
-        molecule.add_bond(
+        molecule._add_bond(
             u,
             v,
             bond_order=info["bond_order"],
             is_aromatic=info["is_aromatic"],
             stereochemistry=info.get("stereochemistry", None),
+            invalidate_cache=False,
         )
     return molecule

--- a/openff/nagl/utils/resonance.py
+++ b/openff/nagl/utils/resonance.py
@@ -512,17 +512,35 @@ class FragmentEnumerator:
         if key in self._path_cache:
             return self._path_cache[key]
 
-        all_paths = map(
-            tuple,
-            nx.all_simple_paths(
-                self.reduced_graph,
-                node_a,
-                node_b,
+        use_rx = True
+        if use_rx:
+            import rustworkx as rx
+            rg = rx.networkx_converter(self.reduced_graph)
+            all_paths_indices: list[list[int]] = rx.all_simple_paths(
+                rg,
+                rg.nodes().index(node_a),
+                rg.nodes().index(node_b),
                 cutoff=max_path_length,
-            ),
-        )
-        odd_paths = [path for path in all_paths if len(path) % 2 == 1]
-        odd_paths = tuple(sorted(odd_paths, key=len, reverse=True))
+            )
+            odd_paths = [tuple(path) for path in all_paths_indices if len(path) % 2 == 1]
+            odd_paths = tuple(sorted(odd_paths, key=len, reverse=True))
+
+            # Need to return payload, not just indices
+            odd_paths = tuple(tuple(rg.nodes()[index] for index in path) for path in odd_paths)
+
+        else:
+            all_paths = map(
+                tuple,
+                nx.all_simple_paths(
+                    self.reduced_graph,
+                    node_a,
+                    node_b,
+                    cutoff=max_path_length,
+                ),
+            )
+            odd_paths = [path for path in all_paths if len(path) % 2 == 1]
+            odd_paths = tuple(sorted(odd_paths, key=len, reverse=True))
+
         self._path_cache[key] = odd_paths
         self._path_cache[key[::-1]] = odd_paths
         return odd_paths


### PR DESCRIPTION
<!-- Does this PR fix an issue or relate to an existing discussion? Please link it below after "Fixes #" -->

When profiling some of the "this big molecule is slow to charge with AshGC" reports, I found that upwards of half of the wall time was spent at [`Molecule._invalidate_cached_properties`](https://github.com/openforcefield/openff-toolkit/blob/9b6189d1ff77be44b21f33715a03845436594e8e/openff/toolkit/topology/molecule.py#L2785). This is called whenever public methods `Molecule.add_atom` or `Molecule.add_bond` are called and, for large molecules, ends up being quite slow. It's not really necessary, though, and can be turned off akin to [how the toolkit deserializes from similar sources](https://github.com/openforcefield/openff-toolkit/blob/9b6189d1ff77be44b21f33715a03845436594e8e/openff/toolkit/topology/molecule.py#L1284-L1291).

Relates to #192 but probably doesn't fix it wholesale

Changes made in this Pull Request:
<!-- Summarise changes made with dot points below -->
 - 
 - 


PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
