### PR TITLE
Start aws gha runner 1.2.0

### DIFF
--- a/.github/workflows/gpu.yaml
+++ b/.github/workflows/gpu.yaml
@@ -28,7 +28,7 @@ jobs:
           aws-region: us-east-1
       - name: Create cloud runner
         id: aws-start
-        uses: omsf/start-aws-gha-runner@v1.1.1
+        uses: omsf/start-aws-gha-runner@v1.2.0
         with:
           aws_image_id: ami-0d5079d9be06933e5
           aws_instance_type: g4dn.xlarge


### PR DESCRIPTION
A variant of #275 hosted on a branch so it has access to CI secrets.
