### PR TITLE
Backport "class property" behavior

### DIFF
--- a/openff/nagl/nn/gcn/_base.py
+++ b/openff/nagl/nn/gcn/_base.py
@@ -8,6 +8,14 @@ from openff.nagl._base.metaregistry import create_registry_metaclass
 from openff.nagl.nn.activation import ActivationFunction
 from openff.nagl.nn._base import ContainsLayersMixin
 
+class classproperty:
+    def __init__(self, func):
+        self.func = func
+
+    def __get__(self, instance, owner):
+        return self.func(owner)
+
+
 GCNLayerType = TypeVar("GCNLayerType", bound=torch.nn.Module)
 
 
@@ -62,32 +70,27 @@ class BaseGCNStack(
 
     # hidden_feature_sizes: List[GCNLayerType]
 
-    @classmethod
-    @property
+    @classproperty
     @abc.abstractmethod
     def name(cls) -> str:
         pass
 
-    @classmethod
-    @property
+    @classproperty
     @abc.abstractmethod
     def available_aggregator_types(cls) -> str:
         """The aggregator options to use for the GCN layers."""
 
-    @classmethod
-    @property
+    @classproperty
     @abc.abstractmethod
     def default_aggregator_type(cls) -> str:
         """The aggregator options to use for the GCN layers."""
 
-    @classmethod
-    @property
+    @classproperty
     @abc.abstractmethod
     def default_dropout(cls) -> str:
         """The aggregator options to use for the GCN layers."""
 
-    @classmethod
-    @property
+    @classproperty
     @abc.abstractmethod
     def default_activation_function(cls) -> str:
         """The aggregator options to use for the GCN layers."""


### PR DESCRIPTION
<!-- Does this PR fix an issue or relate to an existing discussion? Please link it below after "Fixes #" -->

A possible fix for #265 (originally in #286 but can be treated standalone)

Changes made in this Pull Request:
<!-- Summarise changes made with dot points below -->
 - Force minimal `@classproperty` which works with Python 3.13+ / does not raise deprecation warning in Python 3.11+

PR Checklist
------------
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
