### PR TITLE
Fix deprecation(s) for Pytest 10

### DIFF
--- a/openff/nagl/tests/nn/test_model.py
+++ b/openff/nagl/tests/nn/test_model.py
@@ -106,8 +106,9 @@ class TestBaseGNNModel:
 class BaseTestChargeGNNModel:
 
     @pytest.fixture(scope="class")
-    def model(self):
-        return self.get_model()
+    @classmethod
+    def model(cls):
+        return cls.get_model()
 
     @classmethod
     def get_model(cls):


### PR DESCRIPTION
<!-- Does this PR fix an issue or relate to an existing discussion? Please link it below after "Fixes #" -->

Fixes #288

Changes made in this Pull Request:
<!-- Summarise changes made with dot points below -->
 - Do what the Pytest docs say and use `@classmethod` for class-scoped fixture(s)

PR Checklist
------------
 - [x] No `PytestRemovedIn10Warning` in CI logs
 - [ ] Tests?
 - [ ] Docs?
 - [ ] CHANGELOG updated?
 - [ ] Issue raised/referenced?
